### PR TITLE
Readability improvements:

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,25 @@ Examples:
       weber -X GET -H example.org -o output.csv -c "url,method,status,Cache-Control" https://example.com
 ```
 
+## Examples
+
+```bash
+$ weber -o google.csv -c Content-Type,Cache-Control https://google.com
+.................
+Giving up waiting...
+Flushing writer...
+Done.
+```
+
+```bash
+$ cat google.csv
+cat google.csv 
+Content-Type,Cache-Control
+text/html; charset=UTF-8,"private, max-age=0"
+...
+text/javascript; charset=UTF-8,"public, max-age=31536000"
+```
+
 ## Contributing
 
 Weber is an open source project and we welcome contributions from the community. If you would like to contribute, please open an issue or submit a pull request.

--- a/README.md
+++ b/README.md
@@ -29,17 +29,18 @@ go get -u github.com/pavelpascari/weber
 Once you have installed Weber, you can use it to perform various tasks such as:
 
 ```bash
-$ weber                                                               
+$ weber -h
 Usage: weber -o output.csv [OPTIONS] <url>
 
 Options:
   -X <method>   Comma-separated list of HTTP methods to watch for (GET, POST, OPTIONS, PUT, DELETE). Default behavior is to consider all methods.
   -H <string>   Comma-separated list of hostname or IP address to watch for. Default behavior is to consider all hosts.
   -o <file>     Write the response to a file. CSV is the default and only supported format.
-  -c <string>   Comma-separated list of columns to write to the output file. Default is "url,method,status". Available columns are:
-                    status, url, method, Content-Type, Cache-Control, Content-Length
+  -c <string>   Comma-separated list of columns to write to the output file. Default is "url,method,status". 
+                                Available columns are any valid response header, plus: url, method, status.
   -v            Enable verbose logging to observe all browser events.
   -q            Disable all logging.
+  -h            Show this help message.
 
 Examples:
       # Watch for all requests to https://example.com

--- a/requester.go
+++ b/requester.go
@@ -143,6 +143,10 @@ func WatchNetworkFor(ctx context.Context, url string, cfg config, log logF) erro
 		writer.Flush()
 	}()
 
+	if err := writer.Write(cfg.outputCols); err != nil {
+		return fmt.Errorf("failed to write header row: %v", err)
+	}
+
 	for {
 		timeout := time.After(cfg.giveUpAfter)
 
@@ -157,7 +161,7 @@ func WatchNetworkFor(ctx context.Context, url string, cfg config, log logF) erro
 				}
 			}
 		case <-timeout:
-			log("Timeout. Giving up waiting...")
+			log("\nGiving up waiting...")
 			return nil
 		case <-ctx.Done():
 			log("context done...")
@@ -185,9 +189,7 @@ func getRecord(e evt, cfg config, log logF) []string {
 	if len(cfg.domains) > 0 {
 		u, err := url.Parse(e.Request.URL)
 		if err != nil {
-			if cfg.verbose && !cfg.quiet {
-				log("failed to parse url:", e.Request.URL)
-			}
+			log("failed to parse url:", e.Request.URL)
 			return nil
 		}
 

--- a/requester.go
+++ b/requester.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/chromedp/cdproto/network"
@@ -224,16 +223,6 @@ var (
 		"method": func(e evt) string {
 			return e.Request.Method
 		},
-		"Content-Type": func(e evt) string {
-			return getHeaderValue(e.Response.Headers, "Content-Type")
-		},
-		"Cache-Control": func(e evt) string {
-			return getHeaderValue(e.Response.Headers, "Cache-Control")
-		},
-		"Content-Length": func(e evt) string {
-			return getHeaderValue(e.Response.Headers, "Content-Length")
-		},
-
 		"status": func(e evt) string {
 			return strconv.FormatInt(e.Response.Status, 10)
 		},
@@ -246,13 +235,5 @@ func getColValue(e evt, col string) string {
 		return res
 	}
 
-	return "---"
-}
-
-func mergedSupportedCols() string {
-	cols := []string{}
-	for k := range supportedGetters {
-		cols = append(cols, k)
-	}
-	return strings.Join(cols, ", ")
+	return getHeaderValue(e.Response.Headers, http.CanonicalHeaderKey(col))
 }

--- a/requester.go
+++ b/requester.go
@@ -126,7 +126,7 @@ func WatchNetworkFor(ctx context.Context, url string, cfg config, log logF) erro
 		network.Enable(),
 		chromedp.Navigate(url),
 	)
-	if err != nil {
+	if err != nil && err != context.Canceled {
 		return fmt.Errorf("failed to run chromedp: %v", err)
 	}
 
@@ -164,7 +164,6 @@ func WatchNetworkFor(ctx context.Context, url string, cfg config, log logF) erro
 			log("\nGiving up waiting...")
 			return nil
 		case <-ctx.Done():
-			log("context done...")
 			return ctx.Err()
 		}
 	}

--- a/requester.go
+++ b/requester.go
@@ -153,8 +153,9 @@ func WatchNetworkFor(ctx context.Context, url string, cfg config, log logF) erro
 		select {
 		case e := <-proc.out:
 			timeout = nil
-			fmt.Print(".") // progress indicator
-
+			if !cfg.quiet {
+				fmt.Print(".") // progress indicator
+			}
 			if record := getRecord(e, cfg, log); record != nil {
 				if err := writer.Write(record); err != nil {
 					return fmt.Errorf("failed to write record: %v", err)

--- a/weber.go
+++ b/weber.go
@@ -35,10 +35,11 @@ Options:
   -X <method>   Comma-separated list of HTTP methods to watch for (GET, POST, OPTIONS, PUT, DELETE). Default behavior is to consider all methods.
   -H <string>   Comma-separated list of hostname or IP address to watch for. Default behavior is to consider all hosts.
   -o <file>     Write the response to a file. CSV is the default and only supported format.
-  -c <string>   Comma-separated list of columns to write to the output file. Default is "url,method,status". Available columns are:
-                    %s
+  -c <string>   Comma-separated list of columns to write to the output file. Default is "url,method,status". 
+				Available columns are any valid response header, plus: url, method, status.
   -v            Enable verbose logging to observe all browser events.
   -q            Disable all logging.
+  -h            Show this help message.
 
 Examples:
       # Watch for all requests to https://example.com
@@ -75,7 +76,7 @@ type config struct {
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, usage, mergedSupportedCols())
+		fmt.Fprintf(os.Stderr, usage)
 	}
 
 	cfg, err := flagsToConfig()

--- a/weber.go
+++ b/weber.go
@@ -64,6 +64,9 @@ type config struct {
 	// domains is a list of domains to watch for
 	domains []string
 
+	// url is the URL we observe being loaded
+	url string
+
 	// outputPath is the path to the file where the output will be written
 	outputPath string
 	// outputCols is the list of columns to write to the output file
@@ -71,28 +74,70 @@ type config struct {
 }
 
 func main() {
-	supportedCols := mergedSupportedCols()
-
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, usage, supportedCols)
+		fmt.Fprintf(os.Stderr, usage, mergedSupportedCols())
 	}
 
-	flag.Parse()
-	if flag.NArg() < 1 {
-		usageAndExit("")
-	}
-
-	// Make sure the host is provided
-	url := flag.Args()[0]
-	if url == "" {
-		usageAndExit("Missing required argument: url")
+	cfg, err := flagsToConfig()
+	if err != nil {
+		usageAndExit(err.Error())
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
+	log := logger(cfg)
+
+	if err := WatchNetworkFor(ctx, cfg.url, cfg, log); err != nil {
+		errAndExit(err.Error())
+	}
+
+	log("Done.")
+}
+
+type logF func(string, ...any)
+
+func logger(cfg config) logF {
+	return func(msg string, args ...any) {
+		if cfg.quiet {
+			return
+		}
+
+		fmt.Fprintf(os.Stderr, msg, args...)
+		fmt.Fprint(os.Stderr, "\n")
+	}
+}
+
+func usageAndExit(msg string) {
+	if msg != "" {
+		fmt.Fprint(os.Stderr, msg)
+		fmt.Fprint(os.Stderr, "\n\n")
+	}
+	flag.Usage()
+	fmt.Fprint(os.Stderr, "\n")
+	os.Exit(1)
+}
+
+func errAndExit(msg string) {
+	fmt.Fprint(os.Stderr, msg)
+	fmt.Fprint(os.Stderr, "\n")
+	os.Exit(1)
+}
+
+func flagsToConfig() (config, error) {
+	flag.Parse()
+	if flag.NArg() < 1 {
+		return config{}, fmt.Errorf("missing required argument: url")
+	}
+
+	// Make sure the host is provided
+	url := flag.Args()[0]
+	if url == "" {
+		return config{}, fmt.Errorf("provided url argument is empty")
+	}
+
 	cfg := config{
-		quiet:       true,
+		url:         url,
 		giveUpAfter: 5 * time.Second,
 		outputCols:  []string{"url", "method", "status"},
 	}
@@ -102,7 +147,7 @@ func main() {
 		if len(methods) > 0 {
 			for _, m := range methods {
 				if !contains(supportedMethods, m) {
-					usageAndExit(fmt.Sprintf("Unsupported HTTP method: %s", m))
+					return config{}, fmt.Errorf("unsupported HTTP method: %s", m)
 				}
 				cfg.methods = append(cfg.methods, m)
 			}
@@ -121,7 +166,7 @@ func main() {
 	}
 
 	if *o == "" {
-		usageAndExit("Missing required argument: -o")
+		return config{}, fmt.Errorf("missing required argument: -o")
 	} else {
 		cfg.outputPath = *o
 	}
@@ -135,30 +180,5 @@ func main() {
 		cfg.verbose = false
 	}
 
-	if err := WatchNetworkFor(ctx, url, cfg); err != nil {
-		if !cfg.quiet {
-			errAndExit(err.Error())
-		}
-		errAndExit("")
-	}
-
-	if !cfg.quiet {
-		fmt.Println("Done.")
-	}
-}
-
-func usageAndExit(msg string) {
-	if msg != "" {
-		fmt.Fprint(os.Stderr, msg)
-		fmt.Fprint(os.Stderr, "\n\n")
-	}
-	flag.Usage()
-	fmt.Fprint(os.Stderr, "\n")
-	os.Exit(1)
-}
-
-func errAndExit(msg string) {
-	fmt.Fprint(os.Stderr, msg)
-	fmt.Fprint(os.Stderr, "\n")
-	os.Exit(1)
+	return cfg, nil
 }


### PR DESCRIPTION
- [x] abstract away a log function that understands `-q`
- [x] add CSV header
- [x] extract the `flag` parsing into a separate function
- [x] add an example of output to README.md
- [x] handle `os.Interrupt`
-  